### PR TITLE
UI changes in FQ-001 and FQ002

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-002/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-002/certificate.js
@@ -1,92 +1,12 @@
 import { get } from "lodash";
-import { IMG_LOGO, IMG_SEAL, IMG_SSGLOGO, IMG_ORDNANCE } from "../common";
-import { formatDate, formatCertID, getRecipientID } from "../common/functions";
-
-export const fullWidthStyle = {
-  width: "100%",
-  height: "auto"
-};
-
-export const sealWidthStyle = {
-  width: "100%",
-  height: "auto"
-};
-
-export const signatureWidthStyle = {
-  width: "80%",
-  height: "auto"
-};
-
-export const printTextStyle = {
-  fontWeight: "500!important"
-};
-
-export const issuersTextStyle = {
-  fontWeight: "500!important",
-  textAlign: "center",
-  fontSize: "24px"
-};
-
-export const awardTextStyle = {
-  fontSize: "22px",
-  color: "rgb(197,41,155)",
-  fontWeight: "bold",
-  textAlign: "left"
-};
-
-export const singaporeTextStyle = {
-  fontSize: "3rem"
-};
-
-export const nameTextStyle = {
-  fontSize: "2.3rem",
-  textAlign: "left",
-  fontWeight: "bold",
-  wordBreak: "break-word"
-};
-
-export const recipientTextStyle = {
-  fontSize: "1.8rem",
-  textAlign: "center",
-  marginBottom: "0px"
-};
-
-export const titleTextStyle = {
-  color: "rgb(30,93,200)",
-  fontSize: "3rem",
-  textAlign: "center"
-};
-
-export const designationTextStyle = {
-  fontSize: "14px",
-  fontWeight: "bold"
-};
-
-export const footerTextStyle = {
-  fontSize: "12px",
-  color: "rgb(51,0,144)",
-  marginTop: "15px"
-};
-
-export const certCodeStyle = {
-  fontSize: "12px",
-  color: "#ea649c",
-  display: "inline-block",
-  transform: "rotate(-90deg)"
-};
-
-export const footerLogoStyle = {
-  width: "75%",
-  height: "auto"
-};
-export const renderLogoWSQ = () => (
-  <div className="row d-flex" style={{ marginTop: "3rem" }}>
-    <div className="col-lg-6 col-12">
-      <img style={fullWidthStyle} src={IMG_LOGO} />
-    </div>
-    <div className="col-lg-6" />
-  </div>
-);
+import { IMG_SEAL, IMG_SSGLOGO, IMG_ORDNANCE } from "../common";
+import {
+  renderLogoWSQ,
+  renderIssuingDate,
+  renderAwardTextQUAL
+} from "../common/functions";
+import fonts from "../common/fonts";
+import * as styles from "../common/style";
 
 export const renderSignature = certificate => (
   <div
@@ -94,41 +14,44 @@ export const renderSignature = certificate => (
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
     <div className="col-lg-2 col-6">
-      <img style={sealWidthStyle} src={IMG_SEAL} />
+      <img style={styles.sealWidthStyle} src={IMG_SEAL} />
     </div>
 
     <div className="col-lg-7">
       <div className="col-lg-3 col-12">
         <img
-          style={signatureWidthStyle}
+          style={styles.signatureWidthStyle}
           src={get(certificate, "additionalData.certSignatories[0].signature")}
         />
       </div>
-      <div style={designationTextStyle}>
+      <div style={styles.designationTextStyle} className="RobotoBold">
         {get(certificate, "additionalData.certSignatories[0].name")},{" "}
         {get(certificate, "additionalData.certSignatories[0].position")}
       </div>
-      <div style={designationTextStyle}>
+      <div style={styles.designationTextStyle} className="RobotoBold">
         {get(certificate, "additionalData.certSignatories[0].organisation")}
       </div>
       <div style={{ paddingLeft: "0px" }} className="col-lg-5 col-12">
-        <img style={footerLogoStyle} src={IMG_SSGLOGO} />
+        <img style={styles.footerLogoStyle} src={IMG_SSGLOGO} />
       </div>
       <div className="col-lg-10 col-12" style={{ paddingLeft: "0px" }}>
-        <div style={footerTextStyle}>
+        <div style={styles.footerTextStyle} className="RobotoLight">
           The training and assessment of the abovementioned learner are
           accredited
           <br />
           in accordance with the Singapore Workforce Skills Qualifications
           System.
         </div>
-        <div style={footerTextStyle}>
+        <div style={styles.footerTextStyle} className="RobotoLight">
           <a style={{ color: "rgb(51,0,144)" }} href="www.ssg.gov.sg">
             www.ssg.gov.sg
           </a>
           <br />
           For verification of this certificate, please visit{" "}
-          <a href="https://myskillsfuture.sg/verify_eCert.html">
+          <a
+            style={{ color: "rgb(51,0,144)" }}
+            href="https://myskillsfuture.sg/verify_eCert.html"
+          >
             https://myskillsfuture.sg/verify_eCert.html
           </a>
         </div>
@@ -136,69 +59,15 @@ export const renderSignature = certificate => (
     </div>
     <div className="col-lg-3 col-xs-12">
       <div style={{ marginBottom: "70px", marginTop: "60px" }}>
-        <p style={printTextStyle}>
+        <p style={styles.printTextStyle} className="RobotoRegular">
           Cert No: {get(certificate, "additionalData.serialNum")}
         </p>
       </div>
-      <div style={footerTextStyle}>In partnership with</div>
-      <img style={footerLogoStyle} src={IMG_ORDNANCE} />
-      <div style={certCodeStyle}>
+      <div style={styles.footerTextStyle}>In partnership with</div>
+      <img style={styles.footerLogoStyle} src={IMG_ORDNANCE} />
+      <div style={styles.certCodeStyle}>
         {get(certificate, "additionalData.certCode")}
       </div>
-    </div>
-  </div>
-);
-
-export const renderAwardText = certificate => (
-  <div>
-    <div className="d-flex" style={{ marginTop: "2rem" }}>
-      <p style={nameTextStyle}>
-        {get(certificate, "qualificationLevel[0].description")} in{" "}
-        {certificate.name}
-      </p>
-    </div>
-    <div className="d-flex" style={{ marginTop: "3rem" }}>
-      <p style={awardTextStyle}>is awarded to</p>
-    </div>
-    <div className="d-flex" style={{ marginTop: "1rem" }}>
-      <p style={recipientTextStyle}>{certificate.recipient.name}</p>
-    </div>
-    <div className="d-flex">
-      <p style={printTextStyle}>
-        ID No: {getRecipientID(certificate.recipient)}
-      </p>
-    </div>
-    <div
-      className="d-flex col-lg-6 col-12"
-      style={{ marginTop: "1rem", paddingLeft: "0px" }}
-    >
-      <p style={awardTextStyle}>
-        for successful attainment of the required
-        <br />
-        industry approved competencies
-      </p>
-    </div>
-    <div className="d-flex" style={{ marginTop: "3rem" }}>
-      <p style={issuersTextStyle}>
-        at {certificate.additionalData.assessmentOrgName}
-      </p>
-    </div>
-  </div>
-);
-
-export const renderIssuingDate = certificate => (
-  <div className="d-flex" style={{ marginTop: "1rem" }}>
-    <p style={issuersTextStyle}>{formatDate(certificate.attainmentDate)}</p>
-  </div>
-);
-
-export const renderFooter = certificate => (
-  <div className="container">
-    <div className="row d-flex justify-content-center">
-      <div className="col-6 text-left">
-        {get(certificate, "additionalData.additionalCertId")}
-      </div>
-      <div className="col-6 text-right">{formatCertID(certificate.id)}</div>
     </div>
   </div>
 );
@@ -209,10 +78,11 @@ export default ({ logo }) => ({ certificate }) => (
   <div>
     <div
       className="container"
-      style={{ border: 5, borderColor: "#AAA", borderStyle: "solid",paddingLeft:"40px",paddingRight:"40px",paddingBottom:"100px", width:"100%", fontFamily:"Arial" }}
+      style={{ border: 5, borderColor: "#AAA", borderStyle: "solid", paddingLeft:"80px", paddingRight:"80px", paddingTop:"100px", paddingBottom:"100px", width:"100%", fontFamily:"Arial" }}
     >
+      {fonts()}
       {renderLogoWSQ()}
-      {renderAwardText(certificate)}
+      {renderAwardTextQUAL(certificate)}
       {renderIssuingDate(certificate)}
       {certificate.additionalData.certSignatories
         ? renderSignature(certificate)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -156,7 +156,7 @@ export const renderSeal = () => (
 
 export const renderSignature = certificate => (
   <div>
-    <div className="col-lg-3 col-12">
+    <div className="col-lg-4 col-12">
       <img
         style={styles.signatureWidthStyle}
         src={get(certificate, "additionalData.certSignatories[0].signature")}


### PR DESCRIPTION
---
name: Certificate Template Addition
about: This is the workflow for requesting new certificate templates to be added to
  the OpenCerts repository
title: "[New Template]"
labels: new template
assignees: ''

---

# Pull Request Guidelines for Adding Certificate Templates
This document is a work in progress but here are some basic checks. As these are only basic guidelines, meeting the below doesn't indicate there will be no issues with your pull request.

### Certificate Template 
- [ ] No more than 5 templates or 25 added/modified files in the pull request
- [ ] Integration test for each template that checks that the correct rendering is done given a sample certificate
- [ ] Sample certificate file included for each template, located alongside the integration test for each template
- [ ] Sample certificates must obviously be a sample certificate
  - [ ] Obviously fictitious name
  - [ ] Obviously sample signatory images
- [ ] No fixed-size raster images as part of certificate layout
- [ ] Mobile responsive design
- [ ] Date parsing should be localised to template author's timezone
- [ ] Webpack chunking code is correct
  - [ ] Has chunking code
  - [ ] Same chunking code as the other certificates belonging to that institute
- [ ] Certificate Store Addresses have been updated
  - [ ] Template Whitelist
  - [ ] Registry
- [ ] Template should not be using resources(images etc.) on the website outside of their own folder (e.g institute logo shouldn't be used from /static because there's no guarantee it will not change)

### Pre-merge checks

- [ ] Ensure that your code has been [rebased](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) on top of latest OpenCerts master
- [ ] Linter issues resolved (Run `npm run lint:fix` to see issues)
- [ ] `npm run test` passes
- [ ] `npm run test:integration` passes
- [ ] [Travis Build passes](https://docs.travis-ci.com/user/for-beginners/)
